### PR TITLE
Member pruning

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,10 @@ GUILD_ID=your_discord_server_id
 ADMIN_ROLE_ID=admin_role_id_for_commands
 VERIFICATION_CHANNEL_ID=channel_for_verification_logs
 VERIFIED_ROLE_ID=discord_role_for_verification
+#days between member prunes
+PRUNE_DAYS_BETWEEN=15
+#how many hours a member should have been in the server for to be exlucded from prunes
+PRUNE_EXCLUDE_JOINED_HOURS=48
 
 # Backend API Configuration
 API_BASE_URL=https://your-api-server.com

--- a/commands/commandHandlers.js
+++ b/commands/commandHandlers.js
@@ -507,9 +507,44 @@ async function handleCheckVerification(interaction, pendingVerifications) {
   }
 }
 
+/**
+ * Handle /force-prune command
+ * @param {import("discord.js").ChatInputCommandInteraction} interaction 
+ * @param {import("../pruner.js")} pruner
+ */
+async function handleForcePrune(interaction, pruner) {
+  await interaction.deferReply({ ephemeral: true });
+  
+  try {
+    const guild = interaction.guild;
+
+    if (!guild) {
+      await interaction.editReply("❌ This command must be run in a server.");
+      return;
+    }
+    
+    if (!interaction.member.roles.cache.has(config.ADMIN_ROLE_ID)) {
+      await interaction.editReply("❌ You do not have the permissions to do this!");
+      return;
+    }
+
+    if (pruner.pruning) {
+      await interaction.editReply("⚠️ A prune operation is already in progress.");
+      return;
+    }
+
+    await pruner.pruneMembers(guild);
+    await interaction.editReply("✅Force prune completed. Check logs for detailed report.");
+  } catch (err) {
+    console.error("Error in /force-prune:", err);
+    await interaction.editReply("❌ An error occurred while trying to prune members.");
+  }
+}
+
 module.exports = {
   handleVerify,
   handleDebugVerify,
   handleCheckVerification,
-  handleManualApproval
+  handleManualApproval,
+  handleForcePrune
 };

--- a/commands/commandHandlers.js
+++ b/commands/commandHandlers.js
@@ -258,7 +258,7 @@ async function handleDebugVerify(interaction) {
   const discordId = interaction.user.id;
 
   try {
-    const result = await submitVerification(discordId, ckey, true);
+    await submitVerification(discordId, ckey, true);
     
     const embed = new EmbedBuilder()
       .setColor(0xFFFF00)
@@ -359,7 +359,7 @@ async function handleCheckVerification(interaction, pendingVerifications) {
     // Legacy manual approval flow (immediate submission)
     if (pending.type === 'manual_approval') {
       try {
-        const result = await submitVerification(pending.discordId, pending.ckey, false, actualScanRef);
+        await submitVerification(pending.discordId, pending.ckey, false, actualScanRef);
 
         // Remove from pending after submit
         pendingVerifications.delete(actualScanRef);
@@ -440,7 +440,7 @@ async function handleCheckVerification(interaction, pendingVerifications) {
     // If approved, submit and delete iDenfy data
     if (status?.status === 'APPROVED') {
       try {
-        const result = await submitVerification(pending.discordId, pending.ckey, false, actualScanRef);
+        await submitVerification(pending.discordId, pending.ckey, false, actualScanRef);
 
         pendingVerifications.delete(actualScanRef);
 

--- a/commands/commands.js
+++ b/commands/commands.js
@@ -19,7 +19,10 @@ const commands = [
     ),
   new SlashCommandBuilder()
     .setName('check-verification')
-    .setDescription('Check your verification status')
+    .setDescription('Check your verification status'),
+  new SlashCommandBuilder()
+    .setName('force-prune')
+    .setDescription('Force prune members')
 ];
 
 module.exports = commands;

--- a/config/config.js
+++ b/config/config.js
@@ -18,7 +18,8 @@ module.exports = {
   GUILD_ID: process.env.GUILD_ID,
   WEBHOOK_PORT: process.env.WEBHOOK_PORT || 3001,
   VERIFIED_ROLE_ID: process.env.VERIFIED_ROLE_ID,
+  PRUNE_DAYS_BETWEEN: process.env.PRUNE_DAYS_BETWEEN,
+  PRUNE_EXCLUDE_JOINED_HOURS: process.env.PRUNE_EXCLUDE_JOINED_HOURS,
   SENTRY_DSN: process.env.SENTRY_DSN,
-  LOGGER_NEW: BooleanLike(process.env.LOGGER_NEW),
   LOGGER_PRETTY: BooleanLike(process.env.LOGGER_PRETTY),
 };

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -14,8 +14,11 @@ export default defineConfig([
   {
     files: ["**/*.{js,mjs,cjs}"],
     plugins: { js },
-    rules: js.configs.recommended.rules,
+    rules: {
+      "no-unused-vars": ["error", { "argsIgnorePattern": "^_" }]
+    },
     languageOptions: { globals: globals.node },
+    extends: ["js/recommended"],
   },
   {
     files: ["**/*.js"],

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@sentry/node": "^10.10.0",
         "axios": "^1.0.0",
         "body-parser": "^1.20.0",
+        "cross-env": "^10.0.0",
         "discord.js": "^14.0.0",
         "dotenv": "^16.0.0",
         "express": "^4.18.0",
@@ -735,6 +736,12 @@
       "funding": {
         "url": "https://github.com/discordjs/discord.js?sponsor"
       }
+    },
+    "node_modules/@epic-web/invariant": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@epic-web/invariant/-/invariant-1.0.0.tgz",
+      "integrity": "sha512-lrTPqgvfFQtR/eY/qkIzp98OGdNJu0m5ji3q/nJI8v3SXkRKEnWiOxMmbvcSoAIzv/cGiuvRy57k4suKQSAdwA==",
+      "license": "MIT"
     },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.8.0",
@@ -3155,11 +3162,27 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
+    "node_modules/cross-env": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-10.0.0.tgz",
+      "integrity": "sha512-aU8qlEK/nHYtVuN4p7UQgAwVljzMg8hB4YK5ThRqD2l/ziSnryncPNn7bMLt5cFYsKVKBh8HqLqyCoTupEUu7Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@epic-web/invariant": "^1.0.0",
+        "cross-spawn": "^7.0.6"
+      },
+      "bin": {
+        "cross-env": "dist/bin/cross-env.js",
+        "cross-env-shell": "dist/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -4562,7 +4585,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/istanbul-lib-coverage": {
@@ -6877,7 +6899,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -7395,7 +7416,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -7408,7 +7428,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -8052,7 +8071,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"

--- a/pruner.js
+++ b/pruner.js
@@ -1,0 +1,158 @@
+const config = require("./config/config");
+const fs = require("node:fs");
+const logger = require("./utils/logger");
+const { EmbedBuilder } = require("discord.js");
+
+class Pruner {
+  /**
+   * 
+   * @param {import("discord.js").Client} client 
+   * @param {{
+    daysBetweenPrunes: number;
+    excludeRecentJoinHours: number;
+    lastPruneFile: import("fs").PathLike;
+   }} config 
+   */
+  constructor(client, config) {
+    this.client = client;
+    this.pruning = false;
+    this.pruneIntervalVal = null;
+    this.config = config;
+  }
+
+  getLastPruneDate() {
+    try {
+      const data = fs.readFileSync(this.config.lastPruneFile, 'utf8');
+      return JSON.parse(data).lastPrune;
+    } catch {
+      return null;
+    }
+  }
+
+  setLastPruneDate(timestamp) {
+    fs.writeFileSync(this.config.lastPruneFile, JSON.stringify({ lastPrune: timestamp }));
+  }
+
+  /**
+   * Prunes members in a guild based on role and join time.
+   * @param {import("discord.js").Guild} guild 
+   */
+  async pruneMembers(guild) {
+    try {
+      this.pruning = true;
+      logger.info(`Pruning members in guild: ${guild.name}`);
+
+      const now = Date.now();
+      const joinedCutoff = now - this.config.excludeRecentJoinHours * 60 * 60 * 1000;
+
+      let prunedCount, failedPruneCount = 0;
+
+      await guild.members.fetch();
+
+      for (const member of guild.members.cache.values()) {
+        if (member.user.bot) continue;
+        if (member.roles.cache.size <= 1 && (!member.joinedAt || member.joinedAt.getTime() <= joinedCutoff)) {
+          try {
+            await member.kick('Pruned: No roles and not recently joined');
+            prunedCount++;
+          } catch (err) {
+            failedPruneCount++;
+            logger.warn(`Failed to prune member ${member.user.tag}:`, err);
+          }
+        }
+      }
+
+      logger.info(`Pruned ${prunedCount} members with no roles.`);
+
+      let excludedCount = 0;
+      for (const member of guild.members.cache.values()) {
+        if (
+          !member.user.bot &&
+          member.roles.cache.size <= 1 &&
+          member.joinedAt &&
+          member.joinedAt.getTime() > joinedCutoff
+        ) {
+          excludedCount++;
+        }
+      }
+
+      // Send embed to log channel
+      const logChannelId = config.VERIFICATION_CHANNEL_ID;
+      if (logChannelId) {
+        const embed = new EmbedBuilder()
+          .setTitle('Prune Report')
+          .setColor(failedPruneCount ? 0xFF6000 : 0xff9900)
+          .setTimestamp()
+          .setDescription(
+            `**Pruned Members:** ${prunedCount}\n` +
+            `**Excluded (joined in last ${this.config.excludeRecentJoinHours} hours):** ${excludedCount}`
+          );
+
+        if (failedPruneCount) {
+          embed.addFields([{
+            name: "Warning",
+            value: `Failed to prune ${failedPruneCount} members, check Sentry or logs.`
+          }]);
+        }
+
+        const logChannel = guild.channels.cache.get(logChannelId);
+        if (logChannel && logChannel.isTextBased()) {
+          logChannel.send({ embeds: [embed] }).catch(err => {
+            logger.warn('Failed to send prune report embed:', err);
+          });
+        } else {
+          logger.warn('Verification log channel not found or not text-based.');
+        }
+      }
+
+      this.setLastPruneDate(now);
+      this.pruning = false;
+
+    } catch (error) {
+      this.pruning = false;
+      throw error;
+    }
+  }
+
+  async maybePruneOnStartup() {
+    const lastPrune = this.getLastPruneDate();
+    const now = Date.now();
+
+    const daysSinceLastPrune = lastPrune
+      ? (now - lastPrune) / (1000 * 60 * 60 * 24)
+      : Infinity;
+
+    if (daysSinceLastPrune >= this.config.daysBetweenPrunes) {
+      const guild = await this.client.guilds.fetch(config.GUILD_ID);
+      const fullGuild = await guild.fetch();
+      await this.pruneMembers(fullGuild);
+    }
+  }
+
+  startPruneInterval() {
+    const FIVE_MINUTES = 5 * 60 * 1000;
+
+    this.pruneIntervalVal = setInterval(async () => {
+      if (this.pruning) return;
+
+      try {
+        const lastPrune = this.getLastPruneDate();
+        const now = Date.now();
+        const daysSinceLastPrune = lastPrune
+          ? (now - lastPrune) / (1000 * 60 * 60 * 24)
+          : Infinity;
+
+        if (daysSinceLastPrune >= this.config.daysBetweenPrunes) {
+          const guild = await this.client.guilds.fetch(config.GUILD_ID);
+          const fullGuild = await guild.fetch();
+          await this.pruneMembers(fullGuild);
+        }
+      } catch (err) {
+        logger.error('Error during scheduled prune check:', err);
+      }
+    }, FIVE_MINUTES);
+  }
+
+}
+
+module.exports = Pruner;

--- a/pruner.js
+++ b/pruner.js
@@ -51,7 +51,14 @@ class Pruner {
 
       for (const member of guild.members.cache.values()) {
         if (member.user.bot) continue;
-        if (member.roles.cache.size <= 1 && (!member.joinedAt || member.joinedAt.getTime() <= joinedCutoff)) {
+        if (
+          // Make sure the only role they have is @everyone. in this case its just 1 role.
+          member.roles.cache.size <= 1 &&
+          // Make sure they havent joined in the last x days.
+          (!member.joinedAt || member.joinedAt.getTime() <= joinedCutoff) &&
+          // make sure they don't have an active ticket open!
+          !(guild.channels.cache.find(e=>e.permissionOverwrites.resolve(member.id)))
+        ) {
           try {
             await member.kick('Pruned: No roles and not recently joined');
             prunedCount++;

--- a/utils/logger.js
+++ b/utils/logger.js
@@ -20,112 +20,108 @@ if (config.DEBUG) {
   console.warn(`Debug mode enabled${config.SENTRY_DSN && !process.env.SENTRY_DEBUG ? "; Sentry debug can be enabled with SENTRY_DEBUG env.": ""}`);
 }
 
-if (config.LOGGER_NEW) {
-  const logPath = pathJoin(
-    process.cwd(),
-    "logs",
-    `${IS_PRODUCTION ? "prod" : "dev"}_${getFilenameFriendlyUTCDate()}.json`
-  );
-  console.log(`"Logging (JSON Lines) to ${logPath}"`);
-  const transports = [];
+const logPath = pathJoin(
+  process.cwd(),
+  "logs",
+  `${IS_PRODUCTION ? "prod" : "dev"}_${getFilenameFriendlyUTCDate()}.json`
+);
+console.log(`"Logging (JSON Lines) to ${logPath}"`);
+const transports = [];
 
-  // Determine log level based on environment and debug mode
-  let transportLogLevel;
-  if (IS_PRODUCTION) {
-    transportLogLevel = config.DEBUG ? "silly" : "info";
-  } else {
-    transportLogLevel = "silly";
-  }
+// Determine log level based on environment and debug mode
+let transportLogLevel;
+if (IS_PRODUCTION) {
+  transportLogLevel = config.DEBUG ? "silly" : "info";
+} else {
+  transportLogLevel = "silly";
+}
+
+transports.push(
+  new winston.transports.File({
+    filename: logPath,
+    format: winston.format.combine(
+      winston.format.timestamp(),
+      winston.format.json()
+    ),
+    level: transportLogLevel,
+    handleExceptions: true,
+  })
+);
+
+if (config.SENTRY_DSN) {
+  transports.push(
+    new SentryTransport({
+      sentry: {
+        dsn: config.SENTRY_DSN,
+      },
+      level: "error", // just errors
+      exceptionLevels: ["error"],
+    })
+  );
+}
+if (config.LOGGER_PRETTY) {
+  const { inspect } = require("util");
 
   transports.push(
-    new winston.transports.File({
-      filename: logPath,
+    new winston.transports.Console({
+      level: transportLogLevel,
+      format: winston.format.combine(
+        winston.format.colorize({
+          message: true,
+          colors: {
+            info: "blue",
+          },
+          level: true,
+        }),
+        winston.format.timestamp(),
+        winston.format.printf((info) => {
+          let message = info.message;
+          if (typeof message === "object") {
+            message = inspect(message, { depth: null, colors: true });
+          }
+          return `[${info.timestamp}] ${info.level}: ${message}${
+            info.stack ? "\n" + info.stack : ""
+          }`;
+        })
+      ),
+    })
+  );
+} else {
+  transports.push(
+    new winston.transports.Console({
+      level: transportLogLevel,
       format: winston.format.combine(
         winston.format.timestamp(),
         winston.format.json()
       ),
-      level: transportLogLevel,
-      handleExceptions: true,
     })
   );
-
-  if (config.SENTRY_DSN) {
-    transports.push(
-      new SentryTransport({
-        sentry: {
-          dsn: config.SENTRY_DSN,
-        },
-        level: "error", // just errors
-        exceptionLevels: ["error"],
-      })
-    );
-  }
-  if (config.LOGGER_PRETTY) {
-    const { inspect } = require("util");
-
-    transports.push(
-      new winston.transports.Console({
-        level: transportLogLevel,
-        format: winston.format.combine(
-          winston.format.colorize({
-            message: true,
-            colors: {
-              info: "blue",
-            },
-            level: true,
-          }),
-          winston.format.timestamp(),
-          winston.format.printf((info) => {
-            let message = info.message;
-            if (typeof message === "object") {
-              message = inspect(message, { depth: null, colors: true });
-            }
-            return `[${info.timestamp}] ${info.level}: ${message}${
-              info.stack ? "\n" + info.stack : ""
-            }`;
-          })
-        ),
-      })
-    );
-  } else {
-    transports.push(
-      new winston.transports.Console({
-        level: transportLogLevel,
-        format: winston.format.combine(
-          winston.format.timestamp(),
-          winston.format.json()
-        ),
-      })
-    );
-  }
-
-  const logger = winston.createLogger({ transports });
-
-  const flush = async () => {
-    const promises = logger.transports.map((transport) => {
-      return new Promise((resolve) => {
-        if (transport._stream && transport._stream.end) {
-          transport._stream.end(resolve);
-        } else if (transport.close) {
-          transport.close();
-          resolve();
-        } else {
-          resolve();
-        }
-      });
-    });
-    await Promise.all(promises);
-  };
-
-  globalThis._oldExit = process.exit;
-  process.exit = async (...args) => {
-    // Ample amount of time for anything to do it's thing.
-    await sleep(500);
-    await flush();
-    globalThis._oldExit(...args);
-  };
-
-  module.exports = logger;
-} else {
-  module.exports = console;
 }
+
+const logger = winston.createLogger({ transports });
+
+const flush = async () => {
+  const promises = logger.transports.map((transport) => {
+    return new Promise((resolve) => {
+      if (transport._stream && transport._stream.end) {
+        transport._stream.end(resolve);
+      } else if (transport.close) {
+        transport.close();
+        resolve();
+      } else {
+        resolve();
+      }
+    });
+  });
+  await Promise.all(promises);
+};
+
+globalThis._oldExit = process.exit;
+process.exit = async (...args) => {
+  // Ample amount of time for anything to do it's thing.
+  await sleep(500);
+  await flush();
+  globalThis._oldExit(...args);
+};
+
+module.exports = logger;

--- a/webhook/webhookServer.js
+++ b/webhook/webhookServer.js
@@ -1,6 +1,6 @@
 const express = require('express');
 const bodyParser = require('body-parser');
-const { EmbedBuilder } = require('discord.js');
+const { EmbedBuilder, RESTJSONErrorCodes } = require('discord.js');
 const config = require('../config/config');
 const { submitVerification } = require('../services/apiClient');
 const { deleteIdenfyData } = require('../services/idenfyService');
@@ -58,9 +58,9 @@ async function safeSendDM(client, userId, content) {
       });
       
       // Log specific error codes
-      if (sendError.code === 50007) {
+      if (sendError.code === RESTJSONErrorCodes.CannotSendMessagesToThisUser) {
         logger.error(`User ${userId} has DMs disabled or blocked the bot`);
-      } else if (sendError.code === 10013) {
+      } else if (sendError.code === RESTJSONErrorCodes.UnknownUser) {
         logger.error(`User ${userId} not found or invalid user ID`);
       }
       

--- a/webhook/webhookServer.js
+++ b/webhook/webhookServer.js
@@ -141,7 +141,7 @@ function createWebhookServer(client, pendingVerifications) {
   // Webhook endpoint for iDenfy callbacks
   webhookApp.post('/webhook/idenfy', async (req, res) => {
     try {
-      const { scanRef, status, platform } = req.body;
+      const { scanRef, status } = req.body;
       
       // Extract the actual status from the status object
       const overallStatus = status?.overall;


### PR DESCRIPTION
This PR adds automatic member pruning, and keeping track of the last time we pruned.

It comes with 2 amazing new environment variables!
```
# days between member prunes
PRUNE_DAYS_BETWEEN=15
# how many hours a member should have been in the server for to be exlucded from prunes
PRUNE_EXCLUDE_JOINED_HOURS=48
```

Pruning can be manually triggered with the command `/force-prune`

It also changes a few other things.
- Removed `LOGGER_NEW` since it seems to be working "well" in prod (it's bleh, im going to try and fix it in another PR but it is very hard to test this)
- Changes client.on("ready") to "clientReady" due to deprecation: `(node:700735) DeprecationWarning: The ready event has been renamed to clientReady to distinguish it from the gateway READY event and will only emit under that name in v15. Please use clientReady instead.`
- Fixes linter whining
- Changes error code responses in webhookServer to use `RESTJSONErrorCodes` from discord.js

